### PR TITLE
update example code for improved loader-order

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and in webpack
 module.exports = {
     module: {
         loaders: [
-            { test: /\.(png|svg|jpe?g)(\?.*)?$/, loader: "url?limit=800!image-maxsize!image"}
+            { test: /\.(png|svg|jpe?g)(\?.*)?$/, loader: "url?limit=800!image!image-maxsize"}
         ]
     }
 };


### PR DESCRIPTION
since the loaders are applied from right to left, it probably makes sense to first apply the resize and then use the image-webpack-loader to minimize the resized image. 
