### PR TITLE
Use default parameters from loader if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,58 @@
-Webpack module for max size(width/height)
+Webpack module for max size (width/height)
 ========================================
-To be frank, this is a very small loader :P
+This loader will resize images to fit maximum width / height dimensions while retaining their aspect ratio.
 
-ChangeLog
+Changelog
 ---------
-v0.1.0 - Merged code from @danielberndt that added ImageMagick Support and various code cleanup 
+v0.1.0 - Merged code from @danielberndt that added ImageMagick support and various code cleanup
 
 Basic Usage
 -----------
 ```
 npm install image-maxsize-webpack-loader
 ```
-and in webpack
+
+In your webpack config file:
+
 ```js
-//example webpack.config.js, i recommand using url with image
+// Example webpack.config.js. I recommend using the url and image loaders.
 module.exports = {
     module: {
         loaders: [
-            { test: /\.(png|svg|jpe?g)(\?.*)?$/, loader: "url?limit=800!image!image-maxsize"}
+            // The max-width and max-height parameters here are optional. They set the default max dimensions for all images using this loader.
+            { test: /\.(png|svg|jpe?g)(\?.*)?$/, loader: "url?limit=800!image!image-maxsize?max-width=800&max-height=600"}
         ]
     }
 };
 ```
+
+You can specify the maximum size for individual images using the `max-width` and `max-height` query parameters:
+
 ```css
 @media screen and (max-width: 800px) {
-	#abc {
-		background: url('./abc.jpg?max-width=800&max-height=600');
-	}
+    #abc {
+        background: url('./abc.jpg?max-width=800&max-height=600');
+    }
 }
 @media screen and (max-width: 480px) {
-	#abc {
-		background: url('./abc.jpg?max-width=480'); 
-		/* max-width and max-height are both optional, if not provided, it will just be replaced with current height/width of image */
-	}	
+    #abc {
+        background: url('./abc.jpg?max-width=480');
+        /* The max-width and max-height parameters are both optional, if not provided the current height/width of the image will be used. */
+    }
 }
-/* basically the above will shrink the file to fit into a 800x600 file, while retaining its aspect ratio */
+/* The above will shrink the file to fit into a 800x600 file, while retaining its aspect ratio. */
 ```
 
 Requirements
 ------------
 GraphicsMagick _or_ ImageMagick
 
-if you prefer to use ImageMagick add `?useImageMagick=true` to the loader.
+If you prefer to use ImageMagick add `?useImageMagick=true` to the loader.
 
-###Windows User
-I truly recommand installing chocolatey, then you can just
+### Windows Users
+
+I truly recommend installing chocolatey, then you can just run:
+
 ```
 choco install graphicsmagick
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,10 @@ module.exports = function(content) {
 	if ( loaderOptions.skip ) {
 		return content;
 	}
-	var options = loaderUtils.parseQuery(this.resourceQuery), cb = this.async(), width = options['max-width'], height = options['max-height'];
+	var options = loaderUtils.parseQuery(this.resourceQuery);
+	var cb = this.async();
+	var width = options['max-width'];
+	var height = options['max-height'];
 	gm(content).options({imageMagick: loaderOptions.useImageMagick}).size(function(err, value){
 		if ( err ) {
 			return cb(err);

--- a/src/index.js
+++ b/src/index.js
@@ -15,8 +15,8 @@ module.exports = function(content) {
 	}
 	var options = loaderUtils.parseQuery(this.resourceQuery);
 	var cb = this.async();
-	var width = options['max-width'];
-	var height = options['max-height'];
+	var width = options['max-width'] || loaderOptions['max-width'];
+	var height = options['max-height'] || loaderOptions['max-height'];
 	gm(content).options({imageMagick: loaderOptions.useImageMagick}).size(function(err, value){
 		if ( err ) {
 			return cb(err);


### PR DESCRIPTION
Thanks for your super useful module!

Here's a small tweak to allow specifying a max-width/max-height to apply to all images handled by the loader. The options set in individual resource query strings take precedence if they exist.
